### PR TITLE
Fix Filament v4 compatibility issues in resource tables

### DIFF
--- a/app/Filament/Resources/ProjectProgress/ProjectProgressResource.php
+++ b/app/Filament/Resources/ProjectProgress/ProjectProgressResource.php
@@ -37,7 +37,7 @@ class ProjectProgressResource extends Resource
                     ->schema([
                         Select::make('project_id')
                             ->label('Project')
-                            ->relationship('project', 'title')
+                            ->relationship('project', 'project_name')
                             ->searchable()
                             ->preload()
                             ->required()

--- a/app/Filament/Resources/ProjectProgress/Schemas/ProjectProgressForm.php
+++ b/app/Filament/Resources/ProjectProgress/Schemas/ProjectProgressForm.php
@@ -22,7 +22,7 @@ class ProjectProgressForm
                     ->schema([
                         Select::make('project_id')
                             ->label('Project')
-                            ->relationship('project', 'title')
+                            ->relationship('project', 'project_name')
                             ->searchable()
                             ->preload()
                             ->required()

--- a/app/Filament/Resources/ProjectProgress/Tables/ProjectProgressTable.php
+++ b/app/Filament/Resources/ProjectProgress/Tables/ProjectProgressTable.php
@@ -7,7 +7,8 @@ use Filament\Actions\DeleteBulkAction;
 use Filament\Actions\EditAction;
 use Filament\Tables\Columns\BadgeColumn;
 use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\DateFilter;
+use Filament\Tables\Filters\Filter;
+use Filament\Forms\Components\DatePicker;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use App\Models\Project;
@@ -76,7 +77,7 @@ class ProjectProgressTable
             ->filters([
                 SelectFilter::make('project_id')
                     ->label('Project')
-                    ->relationship('project', 'title')
+                    ->relationship('project', 'project_name')
                     ->searchable()
                     ->preload(),
                 SelectFilter::make('status')
@@ -87,8 +88,24 @@ class ProjectProgressTable
                         'delayed' => 'Delayed',
                         'cancelled' => 'Cancelled',
                     ]),
-                DateFilter::make('progress_date')
-                    ->label('Progress Date'),
+                Filter::make('progress_date')
+                    ->form([
+                        DatePicker::make('progress_date_from')
+                            ->label('From'),
+                        DatePicker::make('progress_date_to')
+                            ->label('To'),
+                    ])
+                    ->query(function ($query, array $data) {
+                        return $query
+                            ->when(
+                                $data['progress_date_from'],
+                                fn ($query, $date) => $query->whereDate('progress_date', '>=', $date)
+                            )
+                            ->when(
+                                $data['progress_date_to'],
+                                fn ($query, $date) => $query->whereDate('progress_date', '<=', $date)
+                            );
+                    }),
             ])
             ->actions([
                 EditAction::make(),

--- a/app/Filament/Resources/ScraperJobs/Tables/ScraperJobsTable.php
+++ b/app/Filament/Resources/ScraperJobs/Tables/ScraperJobsTable.php
@@ -9,7 +9,8 @@ use Filament\Actions\EditAction;
 use Filament\Tables\Columns\BadgeColumn;
 use Filament\Tables\Columns\ProgressBarColumn;
 use Filament\Tables\Columns\TextColumn;
-use Filament\Tables\Filters\DateFilter;
+use Filament\Tables\Filters\Filter;
+use Filament\Forms\Components\DatePicker;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use App\Models\ScraperSource;
@@ -114,10 +115,44 @@ class ScraperJobsTable
                 SelectFilter::make('status')
                     ->label('Status')
                     ->options(ScraperJobStatus::options()),
-                DateFilter::make('started_at')
-                    ->label('Started Date'),
-                DateFilter::make('completed_at')
-                    ->label('Completed Date'),
+                Filter::make('started_at')
+                    ->label('Started Date')
+                    ->form([
+                        DatePicker::make('started_from')
+                            ->label('From'),
+                        DatePicker::make('started_to')
+                            ->label('To'),
+                    ])
+                    ->query(function ($query, array $data) {
+                        return $query
+                            ->when(
+                                $data['started_from'],
+                                fn ($query, $date) => $query->whereDate('started_at', '>=', $date)
+                            )
+                            ->when(
+                                $data['started_to'],
+                                fn ($query, $date) => $query->whereDate('started_at', '<=', $date)
+                            );
+                    }),
+                Filter::make('completed_at')
+                    ->label('Completed Date')
+                    ->form([
+                        DatePicker::make('completed_from')
+                            ->label('From'),
+                        DatePicker::make('completed_to')
+                            ->label('To'),
+                    ])
+                    ->query(function ($query, array $data) {
+                        return $query
+                            ->when(
+                                $data['completed_from'],
+                                fn ($query, $date) => $query->whereDate('completed_at', '>=', $date)
+                            )
+                            ->when(
+                                $data['completed_to'],
+                                fn ($query, $date) => $query->whereDate('completed_at', '<=', $date)
+                            );
+                    }),
             ])
             ->actions([
                 EditAction::make(),


### PR DESCRIPTION
## Summary
This PR fixes critical Filament v4 compatibility issues in the admin panel resources that were causing internal server errors.

## Changes Made
- **Updated date filters**: Replaced deprecated `DateFilter` class with Filament v4's `Filter` class using `DatePicker` form components
- **Fixed database column references**: Updated all project relationship references from non-existent `title` column to correct `project_name` column
- **Resources updated**:
  - ProjectProgressTable
  - ProjectProgressResource  
  - ProjectProgressForm
  - ScraperJobsTable

## Technical Details
- Filament v4 removed the `DateFilter` class in favor of using `Filter::make()` with form components
- Date range filtering now uses two DatePicker fields (from/to) with custom query callbacks
- All project relationship selects now correctly reference the `project_name` column that exists in the database

## Testing
- Verified ProjectProgress resource loads without errors
- Confirmed date filters work correctly with range selection
- Tested project dropdown displays project names properly

## Related Issues
Fixes ticket #86d07vzdb